### PR TITLE
fix to work rputs over 64k bytes.

### DIFF
--- a/src/mrb_http2_request.c
+++ b/src/mrb_http2_request.c
@@ -66,7 +66,7 @@ mrb_http2_request_rec *mrb_http2_request_rec_init(mrb_state *mrb)
   r->write_size = 0;
   r->status = 0;
   r->phase = MRB_HTTP2_SERVER_INIT_REQUEST;
-  r->write_buf_64kb = NULL;
+  r->write_large_buf = NULL;
   return r;
 }
 

--- a/src/mrb_http2_request.c
+++ b/src/mrb_http2_request.c
@@ -66,7 +66,7 @@ mrb_http2_request_rec *mrb_http2_request_rec_init(mrb_state *mrb)
   r->write_size = 0;
   r->status = 0;
   r->phase = MRB_HTTP2_SERVER_INIT_REQUEST;
-
+  r->write_buf_64kb = NULL;
   return r;
 }
 

--- a/src/mrb_http2_request.h
+++ b/src/mrb_http2_request.h
@@ -92,6 +92,22 @@ typedef struct {
 
 } mrb_http2_conn_rec;
 
+#define LARGE_BUF_UNIT_LEN 65535
+typedef struct  {
+  // total number of bytes written
+  size_t len;
+
+  // number of bytes allocated
+  size_t alloced_size;
+
+  // buffer
+  char *buf;
+
+  // number of bytes left
+  size_t readleft;
+
+} mrb_http2_large_buf;
+
 typedef struct {
   // http status code
   unsigned int status;
@@ -178,6 +194,8 @@ typedef struct {
   // response type
   mrb_http2_response_type response_type;
 
+  // write buffer from mruby
+  mrb_http2_large_buf *write_buf_64kb;
 } mrb_http2_request_rec;
 
 mrb_http2_request_rec *mrb_http2_request_rec_init(mrb_state *mrb);

--- a/src/mrb_http2_request.h
+++ b/src/mrb_http2_request.h
@@ -93,7 +93,7 @@ typedef struct {
 } mrb_http2_conn_rec;
 
 #define LARGE_BUF_UNIT_LEN 65535
-typedef struct  {
+typedef struct {
   // total number of bytes written
   size_t len;
 

--- a/src/mrb_http2_request.h
+++ b/src/mrb_http2_request.h
@@ -106,6 +106,8 @@ typedef struct  {
   // number of bytes left
   size_t readleft;
 
+  int read_fd;
+
 } mrb_http2_large_buf;
 
 typedef struct {
@@ -195,7 +197,7 @@ typedef struct {
   mrb_http2_response_type response_type;
 
   // write buffer from mruby
-  mrb_http2_large_buf *write_buf_64kb;
+  mrb_http2_large_buf *write_large_buf;
 } mrb_http2_request_rec;
 
 mrb_http2_request_rec *mrb_http2_request_rec_init(mrb_state *mrb);

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -123,11 +123,9 @@ static int mrb_http2_large_buf_write(mrb_http2_large_buf *b, char *src, size_t l
 }
 
 static void mrb_http2_large_buf_close(mrb_http2_large_buf *b, int fd) {
-  ssize_t nread;
-
   TRACER;
   b->readleft = b->len;
-  nread = read(fd, b->buf, 65535);
+  read(fd, b->buf, 65535);
 }
 
 void mrb_http2_large_buf_free(mrb_http2_large_buf *b) {
@@ -2888,7 +2886,7 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
   char *msg;
   mrb_int len;
   int rv;
-  
+
   mrb_get_args(mrb, "s", &msg, &len);
 
   if(r->write_size + len <= LARGE_BUF_UNIT_LEN) {

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -1055,6 +1055,7 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
           0) {
          close(pipefd[0]);
          mrb_http2_large_buf_free(r->write_large_buf);
+         free(r->write_large_buf);
          return -1;
        }
      }

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -1058,6 +1058,7 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
       0) {
       close(pipefd[0]);
       mrb_http2_large_buf_free(r->write_large_buf);
+      free(r->write_large_buf);
       return -1;
     }
   }
@@ -1193,6 +1194,7 @@ TRACER;
       0) {
       close(pipefd[0]);
       mrb_http2_large_buf_free(r->write_large_buf);
+      free(r->write_large_buf);
       return -1;
     }
   }

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -2888,7 +2888,6 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
   char *msg;
   mrb_int len;
   int rv;
-  ssize_t nread;
   mrb_http2_large_buf *b;
 
   mrb_get_args(mrb, "s", &msg, &len);

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -998,6 +998,7 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
   }
   r->write_large_buf = NULL;
   r->write_fd = pipefd[1];
+
   //
   // "set_content" callback ruby block
   //
@@ -1040,20 +1041,17 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
   //
   if (config->callback) {
     r->phase = MRB_HTTP2_SERVER_FIXUPS;
-    callback_ruby_block(mrb, app_ctx->self, config->callback,
-                        config->cb_list->fixups_cb, config->cb_list);
+    callback_ruby_block(mrb, app_ctx->self, config->callback, config->cb_list->fixups_cb, config->cb_list);
   }
   if(r->write_large_buf == NULL) {
     TRACER;
-    if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
-        0) {
+    if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
       close(pipefd[0]);
       return -1;
     }
   } else {
     TRACER;
-    if (send_response_large_buf(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
-      0) {
+    if (send_response_large_buf(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
       close(pipefd[0]);
       mrb_http2_large_buf_free(r->write_large_buf);
       free(r->write_large_buf);
@@ -1178,14 +1176,12 @@ TRACER;
 
   if(r->write_large_buf == NULL) {
     TRACER;
-    if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
-        0) {
+    if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
       close(pipefd[0]);
       return -1;
     }
   } else {
-    if (send_response_large_buf(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
-      0) {
+    if (send_response_large_buf(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
       close(pipefd[0]);
       mrb_http2_large_buf_free(r->write_large_buf);
       free(r->write_large_buf);

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -2877,7 +2877,6 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
   char *msg;
   mrb_int len;
   int rv;
-  mrb_http2_large_buf *b;
 
   mrb_get_args(mrb, "s", &msg, &len);
 
@@ -2888,6 +2887,8 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
     TRACER;
 
     if (r->write_large_buf == NULL) {
+      mrb_http2_large_buf *b;
+
       r->write_large_buf = (mrb_http2_large_buf *)malloc(sizeof(mrb_http2_large_buf));
       if (r->write_large_buf == NULL) {
         fprintf(stderr, "Fatal error: can't alloc mrb_http2_large_buf.\n");

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -2882,6 +2882,7 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
   char *msg;
   mrb_int len;
   int rv;
+  mrb_http2_large_buf *b;
 
   mrb_get_args(mrb, "s", &msg, &len);
 
@@ -2898,7 +2899,7 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
         return mrb_fixnum_value(-1);
       }
       mrb_http2_large_buf_init(r->write_large_buf);
-      mrb_http2_large_buf *b = r->write_large_buf;
+      b = r->write_large_buf;
       b->buf = (char*)malloc(sizeof(char)*(LARGE_BUF_UNIT_LEN));
       if(b->buf == NULL) {
         return mrb_fixnum_value(-1);

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -94,12 +94,6 @@ static void mrb_http2_large_buf_init(mrb_http2_large_buf *b) {
   b->len=0;
   b->buf = NULL;
   b->alloced_size = 0;
-  b->buf = (char*)malloc(sizeof(char)*(LARGE_BUF_UNIT_LEN));
-  if(b->buf == NULL) {
-    return -1;
-  }
-  b->alloced_size = LARGE_BUF_UNIT_LEN;
-  return 0;
 }
 
 static int mrb_http2_large_buf_write(mrb_http2_large_buf *b, char *src, size_t len) {
@@ -632,7 +626,6 @@ static int send_response_large_buf(app_context *app_ctx, nghttp2_session *sessio
 }
 
 static int send_response(app_context *app_ctx, nghttp2_session *session, nghttp2_nv *nva, size_t nvlen,
-                         nghttp2_nv *nva, size_t nvlen,
                          http2_stream_data *stream_data)
 {
   int rv;
@@ -640,21 +633,18 @@ static int send_response(app_context *app_ctx, nghttp2_session *session, nghttp2
   mrb_http2_request_rec *r = app_ctx->r;
   int i;
 
-  TRACER;
   nghttp2_data_provider data_prd;
-  data_prd.source.ptr = r->write_large_buf;
-  data_prd.read_callback = large_buf_read_callback;
+  data_prd.source.ptr = stream_data;
+  data_prd.read_callback = file_read_callback;
 
   if (app_ctx->server->config->debug) {
     for (i = 0; i < nvlen; i++) {
-      debug_header(__func__, nva[i].name, nva[i].namelen, nva[i].value,
-                   nva[i].valuelen);
+      debug_header(__func__, nva[i].name, nva[i].namelen, nva[i].value, nva[i].valuelen);
     }
   }
 
   TRACER;
-  rv = nghttp2_submit_response(session, stream_data->stream_id, nva, nvlen,
-                               &data_prd);
+  rv = nghttp2_submit_response(session, stream_data->stream_id, nva, nvlen, &data_prd);
   if (rv != 0) {
     fprintf(stderr, "Fatal error: %s", nghttp2_strerror(rv));
     mrb_http2_request_rec_free(mrb, r);
@@ -666,8 +656,7 @@ static int send_response(app_context *app_ctx, nghttp2_session *session, nghttp2
   if (app_ctx->server->config->callback) {
     r->phase = MRB_HTTP2_SERVER_LOGGING;
     callback_ruby_block(mrb, app_ctx->self, app_ctx->server->config->callback,
-                        app_ctx->server->config->cb_list->logging_cb,
-                        app_ctx->server->config->cb_list);
+                        app_ctx->server->config->cb_list->logging_cb, app_ctx->server->config->cb_list);
   }
 
   mrb_http2_request_rec_free(mrb, r);
@@ -1005,11 +994,7 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
     fprintf(stderr, "Fatal error: can't alloc mrb_http2_large_buf.\n");
     return -1;
   }
-  rv = mrb_http2_large_buf_init(r->write_large_buf);
-  if(rv != 0) {
-    fprintf(stderr, "Fatal error: mrb_http2_large_buf_init is failed.\n");
-    return -1;
-  }
+  mrb_http2_large_buf_init(r->write_large_buf);
   r->write_fd = pipefd[1];
   r->write_large_buf->read_fd = pipefd[0];
   //
@@ -1136,11 +1121,7 @@ static int mruby_reply(app_context *app_ctx, nghttp2_session *session, http2_str
     fprintf(stderr, "Fatal error: can't alloc mrb_http2_large_buf.\n");
     return -1;
   }
-  rv = mrb_http2_large_buf_init(r->write_large_buf);
-  if(rv != 0) {
-    fprintf(stderr, "Fatal error: mrb_http2_large_buf_init is failed.\n");
-    return -1;
-  }
+  mrb_http2_large_buf_init(r->write_large_buf);
   r->write_fd = pipefd[1];
   c = mrbc_context_new(mrb_inner);
   mrbc_filename(mrb_inner, c, r->filename);
@@ -1200,20 +1181,9 @@ TRACER;
     callback_ruby_block(mrb, app_ctx->self, config->callback, config->cb_list->fixups_cb, config->cb_list);
   }
 
-  if(r->write_large_buf->len == 0) {
-    TRACER;
-    if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
-        0) {
-      close(pipefd[0]);
-      return -1;
-    }
-  } else {
-    if (send_response_large_buf(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
-      0) {
-      close(pipefd[0]);
-      mrb_http2_large_buf_free(r->write_large_buf);
-      return -1;
-    }
+  if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
+    close(pipefd[0]);
+    return -1;
   }
   TRACER;
   return 0;
@@ -2921,7 +2891,6 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
     if(r->write_large_buf != NULL) {
       if(r->write_large_buf->len == 0) {
         TRACER;
-
         b = r->write_large_buf;
         b->buf = (char*)malloc(sizeof(char)*(LARGE_BUF_UNIT_LEN));
         if(b->buf == NULL) {

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -2888,8 +2888,7 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
   char *msg;
   mrb_int len;
   int rv;
-  mrb_http2_large_buf *b;
-
+  
   mrb_get_args(mrb, "s", &msg, &len);
 
   if(r->write_size + len <= LARGE_BUF_UNIT_LEN) {
@@ -2905,7 +2904,7 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
         return mrb_fixnum_value(-1);
       }
       mrb_http2_large_buf_init(r->write_large_buf);
-      b = r->write_large_buf;
+      mrb_http2_large_buf *b = r->write_large_buf;
       b->buf = (char*)malloc(sizeof(char)*(LARGE_BUF_UNIT_LEN));
       if(b->buf == NULL) {
         return mrb_fixnum_value(-1);

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -89,6 +89,57 @@ struct mrb_http2_upstream_client {
   struct evhttp_connection *conn;
 };
 
+static void mrb_http2_large_buf_init(mrb_http2_large_buf *b) {
+  TRACER;
+  b->len=0;
+  b->buf = NULL;
+  b->alloced_size = 0;
+}
+
+static int mrb_http2_large_buf_write(mrb_http2_large_buf *b, char *src, size_t len) {
+  TRACER;
+  // number of bytes available
+  int available_size = b->alloced_size - b->len;
+
+  if(available_size >= len) {
+    TRACER;
+    memcpy(&b->buf[b->len], src, len);
+    b->len += len;
+  } else {
+    TRACER;
+    // when we need more memory
+    int needed_size = len - available_size;
+      int nblocks = (needed_size/LARGE_BUF_UNIT_LEN) + 1;
+      b->buf = (char*)realloc(b->buf,sizeof(char)*(b->alloced_size)+sizeof(char)*(LARGE_BUF_UNIT_LEN*nblocks));
+      if(b->buf == NULL) {
+        TRACER;
+        return -1;
+      }
+      b->alloced_size += LARGE_BUF_UNIT_LEN * nblocks;
+      memcpy(&b->buf[b->len], src, len);
+      b->len += len;
+  }
+  return len;
+}
+
+static void mrb_http2_large_buf_close(mrb_http2_large_buf *b) {
+  TRACER;
+  b->readleft = b->len;
+}
+
+void mrb_http2_large_buf_free(mrb_http2_large_buf *b) {
+  TRACER;
+  if(b->buf != NULL) {
+    TRACER;
+
+    free(b->buf);
+    b->buf = NULL;
+  }
+  b->len = 0;
+  b->alloced_size = 0;
+  b->readleft = 0;
+}
+
 static void mrb_http2_server_free(mrb_state *mrb, void *p)
 {
   mrb_http2_data_t *data = (mrb_http2_data_t *)p;
@@ -473,6 +524,38 @@ static int send_upstream_response(app_context *app_ctx, nghttp2_session *session
   return 0;
 }
 
+static ssize_t large_buf_read_callback(nghttp2_session *session, int32_t stream_id,
+                                   uint8_t *buf, size_t length,
+                                   uint32_t *data_flags,
+                                   nghttp2_data_source *source, void *user_data)
+{
+   mrb_http2_large_buf *b = source->ptr;
+   int feof = -1;
+
+   TRACER;
+
+   if(length > b->readleft) {
+     TRACER;
+     length = b->readleft;
+     feof = 1;
+   }
+   memcpy(buf, &(b->buf[b->len - b->readleft]), length);
+   b->readleft -= length;
+   if (b->readleft == 0||feof == 1) {
+     TRACER;
+
+     if (b->readleft != 0) {
+       return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+     }
+     // Set the eof flag to true
+     *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+     mrb_http2_large_buf_free(b);
+     free(b);
+   }
+   TRACER;
+   return length;
+}
+
 static ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t length,
                                   uint32_t *data_flags, nghttp2_data_source *source, void *user_data)
 {
@@ -496,6 +579,50 @@ static ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id, u
   }
   TRACER;
   return nread;
+}
+
+static int send_response_large_buf(app_context *app_ctx, nghttp2_session *session,
+                          nghttp2_nv *nva, size_t nvlen,
+                          http2_stream_data *stream_data)
+{
+   int rv;
+   mrb_state *mrb = app_ctx->server->mrb;
+   mrb_http2_request_rec *r = app_ctx->r;
+   int i;
+
+   TRACER;
+   nghttp2_data_provider data_prd;
+   data_prd.source.ptr = r->write_large_buf;
+   data_prd.read_callback = large_buf_read_callback;
+
+   if (app_ctx->server->config->debug) {
+     for (i = 0; i < nvlen; i++) {
+       debug_header(__func__, nva[i].name, nva[i].namelen, nva[i].value,
+                    nva[i].valuelen);
+     }
+   }
+
+   TRACER;
+   rv = nghttp2_submit_response(session, stream_data->stream_id, nva, nvlen,
+                                &data_prd);
+   if (rv != 0) {
+     fprintf(stderr, "Fatal error: %s", nghttp2_strerror(rv));
+     mrb_http2_request_rec_free(mrb, r);
+     return -1;
+   }
+   //
+   // "set_logging_cb" callback ruby block
+   //
+   if (app_ctx->server->config->callback) {
+     r->phase = MRB_HTTP2_SERVER_LOGGING;
+     callback_ruby_block(mrb, app_ctx->self, app_ctx->server->config->callback,
+                         app_ctx->server->config->cb_list->logging_cb,
+                         app_ctx->server->config->cb_list);
+   }
+
+   mrb_http2_request_rec_free(mrb, r);
+   TRACER;
+   return 0;
 }
 
 static int send_response(app_context *app_ctx, nghttp2_session *session, nghttp2_nv *nva, size_t nvlen,
@@ -862,9 +989,14 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
     }
     return 0;
   }
-
+  r->write_large_buf = (mrb_http2_large_buf*)malloc(sizeof(mrb_http2_large_buf));
+  if(r->write_large_buf == NULL) {
+    fprintf(stderr, "Fatal error: can't alloc mrb_http2_large_buf.\n");
+    return -1;
+  }
+  mrb_http2_large_buf_init(r->write_large_buf);
   r->write_fd = pipefd[1];
-
+  r->write_large_buf->read_fd = pipefd[0];
   //
   // "set_content" callback ruby block
   //
@@ -890,6 +1022,7 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
   }
 
   close(pipefd[1]);
+  mrb_http2_large_buf_close(r->write_large_buf);
   stream_data->fd = pipefd[0];
   stream_data->readleft = size;
   TRACER;
@@ -907,10 +1040,29 @@ static int content_cb_reply(app_context *app_ctx, nghttp2_session *session, http
     callback_ruby_block(mrb, app_ctx->self, config->callback, config->cb_list->fixups_cb, config->cb_list);
   }
 
-  if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
-    close(pipefd[0]);
-    return -1;
-  }
+     if(r->write_large_buf->len == 0) {
+       TRACER;
+       free(r->write_large_buf);
+       r->write_large_buf = NULL;
+       if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
+           0) {
+         close(pipefd[0]);
+         return -1;
+       }
+     } else {
+       TRACER;
+       if (send_response_large_buf(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) !=
+          0) {
+         close(pipefd[0]);
+         mrb_http2_large_buf_free(r->write_large_buf);
+         return -1;
+       }
+     }
+  // if (send_response(app_ctx, session, r->reshdrs, r->reshdrslen, stream_data) != 0) {
+  //   close(pipefd[0]);
+  //   return -1;
+  // }
+
   TRACER;
   return 0;
 }
@@ -964,6 +1116,12 @@ static int mruby_reply(app_context *app_ctx, nghttp2_session *session, http2_str
     return 0;
   }
 
+  r->write_large_buf = (mrb_http2_large_buf*)malloc(sizeof(mrb_http2_large_buf));
+  if(r->write_large_buf == NULL) {
+    fprintf(stderr, "Fatal error: can't alloc mrb_http2_large_buf.\n");
+    return -1;
+  }
+  mrb_http2_large_buf_init(r->write_large_buf);
   r->write_fd = pipefd[1];
   c = mrbc_context_new(mrb_inner);
   mrbc_filename(mrb_inner, c, r->filename);
@@ -996,7 +1154,6 @@ static int mruby_reply(app_context *app_ctx, nghttp2_session *session, http2_str
   r->reshdrslen += 1;
   MRB_HTTP2_CREATE_NV_LIT_CS(mrb, &r->reshdrs[r->reshdrslen], "last-modified", r->last_modified);
   r->reshdrslen += 1;
-
   if (r->status >= 200 && r->status < 300) {
     size = r->write_size;
   } else {
@@ -1004,8 +1161,9 @@ static int mruby_reply(app_context *app_ctx, nghttp2_session *session, http2_str
     size = strlen(msg);
     rv = write(pipefd[1], msg, size);
   }
-
+TRACER;
   close(pipefd[1]);
+  mrb_http2_large_buf_close(r->write_large_buf);
   stream_data->fd = pipefd[0];
   stream_data->readleft = size;
   TRACER;
@@ -2720,9 +2878,32 @@ static mrb_value mrb_http2_server_rputs(mrb_state *mrb, mrb_value self)
   char *msg;
   mrb_int len;
   int rv;
+  ssize_t nread;
+  mrb_http2_large_buf *b;
 
   mrb_get_args(mrb, "s", &msg, &len);
-  rv = write(write_fd, msg, len);
+
+  if(r->write_size + len <= LARGE_BUF_UNIT_LEN) {
+    TRACER;
+    rv = write(write_fd, msg, len);
+  } else {
+    TRACER;
+    if(r->write_large_buf != NULL) {
+      if(r->write_large_buf->len == 0) {
+        TRACER;
+        b = r->write_large_buf;
+        b->buf = (char*)malloc(sizeof(char)*(LARGE_BUF_UNIT_LEN));
+        if(b->buf == NULL) {
+	  return mrb_fixnum_value(-1);
+        }
+        b->alloced_size = LARGE_BUF_UNIT_LEN;
+
+        nread = read(r->write_large_buf->read_fd, r->write_large_buf->buf, r->write_size);
+        r->write_large_buf->len = nread;
+      }
+      rv = mrb_http2_large_buf_write(r->write_large_buf, msg, len);
+    }
+  }
   r->write_size += len;
 
   return mrb_fixnum_value(rv);


### PR DESCRIPTION
When we rputs over 64k bytes,write system call is blocked.This patch is fix it.